### PR TITLE
DM-35300: Make cell-based coadds pickle-able

### DIFF
--- a/.github/workflows/clang-format.yaml
+++ b/.github/workflows/clang-format.yaml
@@ -11,6 +11,7 @@ jobs:
     name: check C++ formatting
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         path:
           - "include"

--- a/.github/workflows/clang-format.yaml
+++ b/.github/workflows/clang-format.yaml
@@ -1,8 +1,10 @@
 name: check C++ formatting
 
 on:
-  - push
-  - pull_request
+  push:
+    branches:
+      - main
+  pull_request: null
 
 jobs:
   formatting-check:

--- a/.github/workflows/formatting.yaml
+++ b/.github/workflows/formatting.yaml
@@ -5,22 +5,5 @@ on:
   - pull_request
 
 jobs:
-  lint:
-    runs-on: ubuntu-latest
-    name: check Python formatting
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Set up Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.8
-
-      - name: Install
-        run: pip install black isort
-
-      - name: Run isort
-        run: isort --check-only --quiet python/ tests/
-
-      - name: Run black
-        run: black --check python/ tests/
+  call-workflow:
+    uses: lsst/rubin_workflows/.github/workflows/formatting.yaml@main

--- a/.github/workflows/formatting.yaml
+++ b/.github/workflows/formatting.yaml
@@ -1,8 +1,10 @@
 name: check Python formatting
 
 on:
-  - push
-  - pull_request
+  push:
+    branches:
+      - main
+  pull_request: null
 
 jobs:
   call-workflow:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -5,18 +5,5 @@ on:
   - pull_request
 
 jobs:
-  lint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Set up Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.8
-
-      - name: Install
-        run: pip install -r <(curl https://raw.githubusercontent.com/lsst/linting/main/requirements.txt)
-
-      - name: Run linter
-        run: flake8
+  call-workflow:
+    uses: lsst/rubin_workflows/.github/workflows/lint.yaml@main

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,8 +1,10 @@
 name: lint
 
 on:
-  - push
-  - pull_request
+  push:
+    branches:
+      - main
+  pull_request: null
 
 jobs:
   call-workflow:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -42,6 +42,11 @@ jobs:
           setup -v -r .
           scons
 
+      - name: Upload coverage to codecov
+        uses: codecov/codecov-action@v2
+        with:
+          file: ./coverage.xml
+
       - name: Run MyPy
         shell: bash -l {0}
         run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -45,7 +45,9 @@ jobs:
       - name: Upload coverage to codecov
         uses: codecov/codecov-action@v2
         with:
-          file: ./coverage.xml
+          directory: tests/.tests/
+          file: pytest-cell_coadds.xml-cov-cell_coadds.xml
+          fail_ci_if_error: false
 
       - name: Run MyPy
         shell: bash -l {0}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: "ubuntu-latest"
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: conda-incubator/setup-miniconda@v2
         with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,8 +10,10 @@ jobs:
   test:
     name: test
     strategy:
+      fail-fast: false
       matrix:
-        pyver: [3.8]
+        # 3.9 is omitted since there's no stackvana build for py3.9
+        pyver: ["3.8", "3.10"]
 
     runs-on: "ubuntu-latest"
 

--- a/.github/workflows/yamllint.yaml
+++ b/.github/workflows/yamllint.yaml
@@ -1,0 +1,11 @@
+name: Lint YAML Files
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  call-workflow:
+    uses: lsst/rubin_workflows/.github/workflows/yamllint.yaml@main

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,21 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.3.0
+    hooks:
+      - id: check-yaml
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+  - repo: https://github.com/psf/black
+    rev: 22.3.0
+    hooks:
+      - id: black
+        language_version: python3.10
+  - repo: https://github.com/PyCQA/flake8
+    rev: 4.0.1
+    hooks:
+      - id: flake8
+  - repo: https://github.com/pycqa/isort
+    rev: 5.10.1
+    hooks:
+      - id: isort
+        name: isort (python)

--- a/README.rst
+++ b/README.rst
@@ -2,6 +2,17 @@
 cell_coadds
 ###########
 
+
+|build|
+|coverage|
+
+.. |build| image:: https://github.com/lsst-dm/cell_coadds/actions/workflows/test.yaml/badge.svg?branch=main
+   :target: https://github.com/lsst-dm/cell_coadds/actions/workflows/test.yaml
+
+.. |coverage| image:: https://codecov.io/github/lsst-dm/cell_coadds/branch/main/graph/badge.svg
+   :target: https://codecov.io/github/lsst-dm/cell_coadds
+
+
 ``cell_coadds`` is a package being developed for eventual inclusion in the `LSST Science Pipelines <https://pipelines.lsst.io>`_.
 
 It will eventually include code for building coadds of astronomical images in small (few arcsecond) cells, in which only input images that fully contain a cell are included.

--- a/README.rst
+++ b/README.rst
@@ -63,3 +63,13 @@ They include:
 
 The best way to use all of these tools is via editor integrations, which should be possible for all major editors.
 All necessary configuration files for these tools are included in the repository (``pyproject.toml``, ``mypy.ini``, and ``.clang-format``), and these configurations should be allowed to take precedence over any others to ensure the CI checks that use those configurations are satisfied.
+Additionally, you may `install a pre-commit <https://pre-commit.com/#installation>`_ hook to ensure that the staged changes are in accordance with these conventions.
+
+.. code-block:: sh
+
+    $ pip install pre-commit
+    $ pre-commit install
+
+Because the CI happens solely on Github Actions and because it can take a long time, auto-merge is enabled for this repository.
+As an extra safeguard, an approval is required before merging unlike other LSST repositories.
+since it is common for reviewers to approve PRs after suggesting minor changes, **the auto-merge option must be used only after the reviewer's comments are addressed**.

--- a/bin.src/SConscript
+++ b/bin.src/SConscript
@@ -1,3 +1,4 @@
 # -*- python -*-
 from lsst.sconsUtils import scripts
+
 scripts.BasicSConscript.shebang()

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,4 +1,5 @@
 [mypy]
+show_error_codes = True
 warn_unused_configs = True
 warn_redundant_casts = True
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -26,3 +26,7 @@ warn_unused_ignores = True
 
 [mypy-lsst.cell_coadds.version]
 ignore_missing_imports = True
+
+# mypy does not bode well with monkey patching done here.
+[mypy-lsst.cell_coadds._GridContainer]
+ignore_errors = True

--- a/python/lsst/cell_coadds/_GridContainer.py
+++ b/python/lsst/cell_coadds/_GridContainer.py
@@ -1,0 +1,88 @@
+# This file is part of cell_coadds.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+from __future__ import annotations
+
+from itertools import product
+from typing import Any, Dict, List
+
+from lsst.skymap import Index2D
+from lsst.utils import continueClass
+
+from ._cell_coadds import GridContainer, GridContainerBuilder
+
+__all__: List[str] = []
+
+
+@continueClass
+class GridContainerBuilder:  # noqa: F811
+    def __getstate__(self) -> Dict:
+        gc: GridContainer = self.finish()
+        x_iter = range(self.offset.x, self.offset.x + self.shape.x)
+        y_iter = range(self.offset.y, self.offset.y + self.shape.y)
+        yx_iter = product(y_iter, x_iter)
+        state = {}
+        for (y, x) in yx_iter:
+            state[Index2D(x, y)] = gc[Index2D(x, y)]
+        return state
+
+    def __setstate__(self, state: Dict) -> None:
+        x_iter = range(self.offset.x, self.offset.x + self.shape.x)
+        y_iter = range(self.offset.y, self.offset.y + self.shape.y)
+        yx_iter = product(y_iter, x_iter)
+        for (y, x), value in zip(yx_iter, state.values()):
+            self.set(x=x, y=y, value=value)
+        self.finish()
+
+    def __reduce__(self) -> tuple:
+        state = self.__getstate__()
+        return (GridContainerBuilder, (self.shape, self.offset), state)
+
+
+@continueClass
+class GridContainer:  # noqa: F811
+    def __getstate__(self) -> Dict:
+        """Support pickle with pickle.dump(s)."""
+        state: Dict[Any, Any] = {"shape": self.shape, "offset": self.offset}
+        for y in range(self.offset.y, self.offset.y + self.shape.y):
+            for x in range(self.offset.x, self.offset.x + self.shape.x):
+                state[Index2D(x, y)] = self[Index2D(x, y)]
+        return state
+
+    def __setstate__(self, state: Dict) -> GridContainer:
+        """Support unpickle with pickle.load(s)."""
+        builder: GridContainerBuilder = GridContainerBuilder(self.shape, self.offset)
+        x_iter = range(self.offset.x, self.offset.x + self.shape.x)
+        y_iter = range(self.offset.y, self.offset.y + self.shape.y)
+        yx_iter = product(y_iter, x_iter)
+        for (y, x), value in zip(yx_iter, state):
+            builder.set(x=x, y=y, value=value)
+        return builder.finish()
+
+    def __reduce__(self) -> tuple:
+        builder: GridContainerBuilder = GridContainerBuilder(self.shape, self.offset)
+        x_iter = range(self.offset.x, self.offset.x + self.shape.x)
+        y_iter = range(self.offset.y, self.offset.y + self.shape.y)
+        yx_iter = product(y_iter, x_iter)
+        for (y, x), value in zip(yx_iter, self):
+            builder.set(x=x, y=y, value=value)
+        builder.finish()
+        return (builder.finish, (), list(self.__iter__()))

--- a/python/lsst/cell_coadds/_UniformGrid.cc
+++ b/python/lsst/cell_coadds/_UniformGrid.cc
@@ -73,6 +73,17 @@ void wrapUniformGrid(utils::python::WrapperCollection& wrappers) {
         cls.def_property_readonly("bbox", &UniformGrid::get_bbox, py::return_value_policy::copy);
         cls.def_property_readonly("cell_size", &UniformGrid::get_cell_size, py::return_value_policy::copy);
         cls.def_property_readonly("shape", &UniformGrid::get_shape, py::return_value_policy::copy);
+        cls.def(py::pickle(
+            [](const UniformGrid& self) {  // __getstate__
+                return py::make_tuple(self.get_bbox(), self.get_cell_size());
+            },
+            [](py::tuple t) {  // __setstate__
+                if (t.size() != 2) {
+                    throw std::runtime_error(
+                        "Tuple size = " + std::to_string(t.size()) + "; must be 2 for UniformGrid");
+                }
+                return new UniformGrid(t[0].cast<geom::Box2I>(), t[1].cast<geom::Extent2I>());
+            }));
     });
 }
 

--- a/python/lsst/cell_coadds/__init__.py
+++ b/python/lsst/cell_coadds/__init__.py
@@ -22,6 +22,7 @@
 from . import typing_helpers
 from ._cell_coadds import *
 from ._common_components import *
+from ._GridContainer import *
 from ._identifiers import *
 from ._image_planes import *
 from ._multiple_cell_coadd import *

--- a/python/lsst/cell_coadds/_single_cell_coadd.py
+++ b/python/lsst/cell_coadds/_single_cell_coadd.py
@@ -30,6 +30,7 @@ from lsst.geom import Box2I
 
 from ._common_components import CommonComponents, CommonComponentsProperties
 from ._image_planes import ImagePlanes, OwnedImagePlanes, ViewImagePlanes
+from .typing_helpers import ImageLike
 
 if TYPE_CHECKING:
     from ._identifiers import CellIdentifiers, ObservationIdentifiers
@@ -77,7 +78,8 @@ class SingleCellCoadd(CommonComponentsProperties):
         ), f"Cell inner bbox {inner_bbox} is not contained by outer bbox {outer.bbox}."
         self._outer = outer
         self._psf = psf
-        self._inner = ViewImagePlanes(outer, bbox=inner_bbox, make_view=lambda image: image[inner_bbox])
+        self._inner_bbox = inner_bbox
+        self._inner = ViewImagePlanes(outer, bbox=inner_bbox, make_view=self._make_view)
         self._common = common
         self._inputs = inputs
         self._identifiers = identifiers
@@ -115,3 +117,6 @@ class SingleCellCoadd(CommonComponentsProperties):
     def common(self) -> CommonComponents:
         # Docstring inherited.
         return self._common
+
+    def _make_view(self, image: ImageLike) -> ImageLike:
+        return image[self._inner_bbox]

--- a/tests/test_UniformGrid.py
+++ b/tests/test_UniformGrid.py
@@ -21,6 +21,7 @@
 
 from __future__ import annotations
 
+import pickle
 import unittest
 
 from lsst.cell_coadds import UniformGrid
@@ -101,6 +102,12 @@ class UniformGridTestCase(unittest.TestCase):
             grid.min_of(1, 3)
         with self.assertRaises(TypeError):
             grid.bbox_of(1, 3)
+
+    def test_pickle(self):
+        """Test that UniformGrid objects are pickleable."""
+        grid1 = UniformGrid(self.bbox, self.cell_size)
+        grid2 = pickle.loads(pickle.dumps(grid1, pickle.HIGHEST_PROTOCOL))
+        self.assertEqual(grid1, grid2)
 
 
 if __name__ == "__main__":

--- a/tests/test_UniformGrid.py
+++ b/tests/test_UniformGrid.py
@@ -107,6 +107,7 @@ class UniformGridTestCase(unittest.TestCase):
         """Test that UniformGrid objects are pickleable."""
         grid1 = UniformGrid(self.bbox, self.cell_size)
         grid2 = pickle.loads(pickle.dumps(grid1, pickle.HIGHEST_PROTOCOL))
+        self.assertIsInstance(grid2, UniformGrid)
         self.assertEqual(grid1, grid2)
 
 

--- a/ups/cell_coadds.cfg
+++ b/ups/cell_coadds.cfg
@@ -8,7 +8,7 @@ import lsst.sconsUtils
 # Otherwise, the rules for which packages to list here are the same as those for
 # table files.
 dependencies = {
-    "required": ["utils", "ndarray", "meas_algorithms"],
+    "required": ["ndarray", "meas_algorithms"],
     "buildRequired": ["boost_test", "pybind11", "ndarray", "pex_exceptions"],
     "optional": [],
     "buildOptional": [],


### PR DESCRIPTION
Creating a PR in draft mode for some early comments.

1. The `UniformGrid` was quite simple to implement the pickle in pybind11.
2. The `GridContainer` and its builder need quite some logic to be done while dumping and then loading, so I chose to use `continueClass` and implement them in python.
3. Pickling and unpickling seem accurate, but the equality fails, probably because there is no explicit definition of `__eq__` for these objects unlike `UniformGrid`.

Things on to-do list:

- [ ]  Implement `__eq__` for `GridContainer` and `GridContainerBuilder`
- [ ]  Create some convenience routines to iterate over the grids, either in C++ or in Python, since there's quite some repetiton.
- [x] Format code correctly.